### PR TITLE
Update points doc with calculator

### DIFF
--- a/docs/points-system.mdx
+++ b/docs/points-system.mdx
@@ -1,5 +1,7 @@
 # Points System
 
+import PointsCalculator from '@site/src/components/PointsCalculator';
+
 The **WeissFi Points System** rewards users for borrowing and staking. The longer you keep debt open or your DORI staked, the faster your points grow — with different formulas for each activity.
 
 Points are used to measure user contribution and may be used in future reward distributions or protocol incentives.
@@ -16,18 +18,18 @@ Points are used to measure user contribution and may be used in future reward di
 | Duration | Points Earned |
 |----------|----------------|
 | 1 day    | 2              |
-| 7 days   | 75             |
-| 30 days  | 827            |
-| 90 days  | 4,440          |
+| 7 days   | 55             |
+| 30 days  | 649            |
+| 90 days  | 4,200          |
 
 ### Staking Points (Example with $1,000 Staked)
 
 | Duration | Points Earned |
 |----------|----------------|
 | 1 day    | 6              |
-| 7 days   | 112            |
-| 30 days  | 659            |
-| 90 days  | 2,301          |
+| 7 days   | 91             |
+| 30 days  | 702            |
+| 90 days  | 3,267          |
 
 ---
 
@@ -47,6 +49,10 @@ vaultPoints = doc.vaultPoints + (lastDebtValue / 1e9) × (vaultDays)^1.7 × 0.00
 
 vaultPoints = 2 × (days)^1.7
 
+For example, keeping **$1,000** of debt for **30 days** gives:
+
+1000 × 30^1.7 × 1 × 0.002 = **648.838** points
+
 ---
 
 ## 🔢 Staking Points Formula
@@ -65,6 +71,15 @@ stakingPoints = doc.stakingPoints + (lastStakingValue / 1e9) × (stakingDays)^1.
 **Simplified (with $1,000 staked):**
 
 stakingPoints = 6 × (days)^1.4
+
+Staking **$1,000** for **30 days** results in:
+
+1000 × 30^1.4 × 1.2 × 0.005 = **701.651** points
+
+## 📅 Monthly Points Calculator
+
+
+<PointsCalculator />
 
 
 ---

--- a/src/components/PointsCalculator.tsx
+++ b/src/components/PointsCalculator.tsx
@@ -1,0 +1,24 @@
+import React, {useState} from 'react';
+
+export default function PointsCalculator() {
+  const [debt, setDebt] = useState(1000);
+  const [stake, setStake] = useState(1000);
+
+  const vault = (debt * Math.pow(30, 1.7) * 0.002).toFixed(2);
+  const staking = (stake * Math.pow(30, 1.4) * 1.2 * 0.005).toFixed(2);
+
+  return (
+    <div style={{border: '1px solid #ccc', padding: '1rem', marginTop: '1rem'}}>
+      <div>
+        <label>Debt ($)&nbsp;</label>
+        <input type="number" value={debt} onChange={e => setDebt(Number(e.target.value))} />
+      </div>
+      <div style={{marginTop: '0.5rem'}}>
+        <label>Staking ($)&nbsp;</label>
+        <input type="number" value={stake} onChange={e => setStake(Number(e.target.value))} />
+      </div>
+      <p style={{marginTop: '0.5rem'}}>Monthly vault points: <strong>{vault}</strong></p>
+      <p>Monthly staking points: <strong>{staking}</strong></p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- correct example calculations in points doc
- add a monthly points calculator component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685a90809e44832b99212a6dcded2082