### PR TITLE
Add oracle documentation

### DIFF
--- a/docs/oracles.md
+++ b/docs/oracles.md
@@ -1,0 +1,11 @@
+# Oracles
+
+Weiss Finance integrates multiple on-chain price oracles to fetch real-time price data used across the protocol. We utilize **Pyth**, **Switchboard**, and **Stork** to ensure reliable market prices for supported assets.
+
+Oracle data is queried during key protocol operations, including:
+
+- Opening or modifying vaults
+- Updating collateral ratios
+- Triggering liquidations when positions fall below required safety thresholds
+
+Accurate price feeds ensure the protocol remains solvent and behaves predictably. These oracles are critical for calculating each user's health factor and determining when positions become undercollateralized.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -12,6 +12,7 @@ const sidebars: SidebarsConfig = {
         'earn',
         'fees',
         'redemption',
+        'oracles',
         'points-system',
         'vault-drop-campaign',
       ],


### PR DESCRIPTION
## Summary
- document the oracles used in WeissFi
- include the new doc in the sidebar

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_685aadd26890832ba8cdceed402f2620