### PR TITLE
Add FlowX liquidity formula

### DIFF
--- a/docs/points-system.mdx
+++ b/docs/points-system.mdx
@@ -76,6 +76,27 @@ Staking **$1,000** for **30 days** results in:
 
 1000 × 30^1.4 × 1.2 × 0.005 = **701.651** points
 
+---
+
+## 🔢 FlowX Points Formula
+
+flowXPoints += (liquidity / 1e9) × (days)^2.0 × multiplier × 0.015
+
+Parameters:
+- **liquidity** – amount of liquidity provided (scaled from wei)
+- **days** – number of days of liquidity provision
+- **multiplier** – event bonus multiplier (default `1.0`)
+- **Exponent** – `2.0` (quadratic growth rewards longer commitment)
+- **Scaling factor** – `0.015` (highest reward rate across all point types)
+
+**Simplified (with $1,000 liquidity, multiplier 1.0):**
+
+flowXPoints = 15 × (days)^2.0
+
+Providing **$1,000** of liquidity for **30 days** results in:
+
+1000 × 30^2.0 × 1 × 0.015 = **13,500** points
+
 ## 📅 Monthly Points Calculator
 
 

--- a/docs/points-system.mdx
+++ b/docs/points-system.mdx
@@ -31,6 +31,15 @@ Points are used to measure user contribution and may be used in future reward di
 | 30 days  | 702            |
 | 90 days  | 3,267          |
 
+### FlowX Points (Example with $1,000 Liquidity)
+
+| Duration | Points Earned |
+|----------|----------------|
+| 1 day    | 15             |
+| 7 days   | 735            |
+| 30 days  | 13,500         |
+| 90 days  | 121,500        |
+
 ---
 
 ## 🔢 Vault Points Formula

--- a/src/components/PointsCalculator.tsx
+++ b/src/components/PointsCalculator.tsx
@@ -4,11 +4,10 @@ export default function PointsCalculator() {
   const [debt, setDebt] = useState(1000);
   const [stake, setStake] = useState(1000);
   const [liquidity, setLiquidity] = useState(1000);
-  const [multiplier, setMultiplier] = useState(1);
 
   const vault = (debt * Math.pow(30, 1.7) * 0.002).toFixed(2);
   const staking = (stake * Math.pow(30, 1.4) * 1.2 * 0.005).toFixed(2);
-  const flowx = (liquidity * Math.pow(30, 2) * multiplier * 0.015).toFixed(2);
+  const flowx = (liquidity * Math.pow(30, 2) * 0.015).toFixed(2);
 
   return (
     <div style={{border: '1px solid #ccc', padding: '1rem', marginTop: '1rem'}}>
@@ -26,15 +25,6 @@ export default function PointsCalculator() {
           type="number"
           value={liquidity}
           onChange={e => setLiquidity(Number(e.target.value))}
-        />
-      </div>
-      <div style={{marginTop: '0.5rem'}}>
-        <label>Multiplier&nbsp;</label>
-        <input
-          type="number"
-          step="0.1"
-          value={multiplier}
-          onChange={e => setMultiplier(Number(e.target.value))}
         />
       </div>
       <p style={{marginTop: '0.5rem'}}>Monthly vault points: <strong>{vault}</strong></p>

--- a/src/components/PointsCalculator.tsx
+++ b/src/components/PointsCalculator.tsx
@@ -3,9 +3,12 @@ import React, {useState} from 'react';
 export default function PointsCalculator() {
   const [debt, setDebt] = useState(1000);
   const [stake, setStake] = useState(1000);
+  const [liquidity, setLiquidity] = useState(1000);
+  const [multiplier, setMultiplier] = useState(1);
 
   const vault = (debt * Math.pow(30, 1.7) * 0.002).toFixed(2);
   const staking = (stake * Math.pow(30, 1.4) * 1.2 * 0.005).toFixed(2);
+  const flowx = (liquidity * Math.pow(30, 2) * multiplier * 0.015).toFixed(2);
 
   return (
     <div style={{border: '1px solid #ccc', padding: '1rem', marginTop: '1rem'}}>
@@ -17,8 +20,26 @@ export default function PointsCalculator() {
         <label>Staking ($)&nbsp;</label>
         <input type="number" value={stake} onChange={e => setStake(Number(e.target.value))} />
       </div>
+      <div style={{marginTop: '0.5rem'}}>
+        <label>FlowX Liquidity ($)&nbsp;</label>
+        <input
+          type="number"
+          value={liquidity}
+          onChange={e => setLiquidity(Number(e.target.value))}
+        />
+      </div>
+      <div style={{marginTop: '0.5rem'}}>
+        <label>Multiplier&nbsp;</label>
+        <input
+          type="number"
+          step="0.1"
+          value={multiplier}
+          onChange={e => setMultiplier(Number(e.target.value))}
+        />
+      </div>
       <p style={{marginTop: '0.5rem'}}>Monthly vault points: <strong>{vault}</strong></p>
       <p>Monthly staking points: <strong>{staking}</strong></p>
+      <p>Monthly FlowX points: <strong>{flowx}</strong></p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- document FlowX rewards formula on points system page
- update calculator to include FlowX liquidity projections

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_685d3994a2c4832bb489e12ab2ea714d