### PR TITLE
Add roadmap and analytics doc

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,3 @@
+# Analytics Dashboard
+
+Explore protocol data with our [Sentio dashboard](https://dash.sentio.xyz/dashboard/weissfi/weiss-finance). We will continue adding new on-chain analytics powered by our public package.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,3 @@
+# Roadmap
+
+Stay up to date with WeissFi development and feature requests on our [FeatureBase board](https://weissfinance.featurebase.app/). There you can see what we're working on and suggest improvements.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -25,6 +25,8 @@ const sidebars: SidebarsConfig = {
         'faq',
         'mainnet-package',
         'media-kit',
+        'roadmap',
+        'analytics',
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- split the roadmap and analytics documentation
- register new analytics page in the sidebar
- run Docusaurus build to verify docs compile

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685fbe5a342c832bbd00133c8c8643c2