### PR TITLE
Add roadmap and analytics doc

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,3 @@
+# Analytics Dashboard
+
+Explore protocol data with our [https://dash.sentio.xyz/dashboard/weissfi/weiss-finance](https://dash.sentio.xyz/dashboard/weissfi/weiss-finance) dashboard. We will continue adding new on-chain analytics powered by our public package.

--- a/docs/roadmap-feedback.md
+++ b/docs/roadmap-feedback.md
@@ -1,0 +1,3 @@
+# Roadmap & Feedback
+
+Stay up to date with WeissFi development and share suggestions on our [https://weissfinance.featurebase.app/](https://weissfinance.featurebase.app/). There you can track progress and contribute ideas.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -25,6 +25,8 @@ const sidebars: SidebarsConfig = {
         'faq',
         'mainnet-package',
         'media-kit',
+        'roadmap-feedback',
+        'analytics',
       ],
     },
   ],

--- a/src/components/HomepageFeatures/RoadmapSection.tsx
+++ b/src/components/HomepageFeatures/RoadmapSection.tsx
@@ -7,12 +7,12 @@ export default function RoadmapSection() {
   return (
     <div className={styles.roadmapSection}>
       <Heading as="h2" className="text--center margin-bottom--md">
-        Roadmap
+        Roadmap & Feedback
       </Heading>
       <div className="text--center">
-        <p>Check our progress and upcoming features on Trello.</p>
-        <Link to="https://trello.com/b/xyz123/weissfi-roadmap" target="_blank">
-          View Roadmap
+        <p>Check our progress and leave feedback on FeatureBase.</p>
+        <Link to="https://weissfinance.featurebase.app/" target="_blank">
+          https://weissfinance.featurebase.app/
         </Link>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- split the roadmap and analytics documentation
- register new analytics page in the sidebar
- rename roadmap page to "Roadmap & Feedback" and update home page link
- show full URLs for roadmap and analytics links
- run Docusaurus build to verify docs compile

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685fbe5a342c832bbd00133c8c8643c2